### PR TITLE
Fix for setting parameters in ros2 launch

### DIFF
--- a/camera_simulator/camera_simulator.py
+++ b/camera_simulator/camera_simulator.py
@@ -184,7 +184,7 @@ def main(args=None):
     parser.add_argument('--loop', action='store_true', help='loop video after end')
     parser.set_defaults(loop=False)
 
-    extra_args = parser.parse_args()
+    extra_args, unknown = parser.parse_known_args()
 
     rclpy.init(args=args)
 


### PR DESCRIPTION
Before this fix, the mixing of CLI args and ROS args doesn't work properly due to Argparser trying to parse the ROS args:
```
root@157a769a5753:/workspace# ros2 run camera_simulator camera_simulator --type video --path /videos/camera0.mov --loop --ros-args -p image_topic:='raw_images'
usage: camera_simulator [-h] --path PATH [--calibration_file CALIBRATION_FILE] [--type TYPE] [--start START] [--loop]
camera_simulator: error: unrecognized arguments: --ros-args -p image_topic:=raw_images
[ros2run]: Process exited with failure 2
```
Using `parse_known_args` allows the ROS args to be ignored by Argparser:

```
root@157a769a5753:/workspace# ros2 run camera_simulator camera_simulator --type video --path /videos/camera0.mov --loop --ros-args -p image_topic:='raw_images'
[WARN] [1724981204.855762100] [camera_simulator]: Could not find calibration file , will proceed without a calibration file
[INFO] [1724981204.918909368] [camera_simulator]: Publishing image with 30.0 fps
```